### PR TITLE
Several improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See: [Serverless Framework Documentation](http://docs.serverless.com)
 ```
 $ git clone https://github.com/haw-itn/serverless-web-monitor.git
 $ cd serverless-web-monitor
-$ export AWS_DEFAULT_REGION=ap-southeast-2
+$ export AWS_REGION=ap-southeast-2
 $ npm install
 $ sls deploy
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See: [Serverless Framework Documentation](http://docs.serverless.com)
 ```
 $ git clone https://github.com/haw-itn/serverless-web-monitor.git
 $ cd serverless-web-monitor
+$ export AWS_DEFAULT_REGION=ap-southeast-2
 $ npm install
 $ sls deploy
 ```

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ See: [Serverless Framework Documentation](http://docs.serverless.com)
 ```
 $ git clone https://github.com/haw-itn/serverless-web-monitor.git
 $ cd serverless-web-monitor
-$ export AWS_REGION=ap-southeast-2
 $ npm install
+
+# optional, overwrite the default region used. Default is us-east-1
+$ export AWS_REGION=ap-southeast-2
+
 $ sls deploy
 ```
 

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -8,9 +8,7 @@ const dynamoConfig = {
   region:          process.env.AWS_REGION
 };
 const docClient = new AWS.DynamoDB.DocumentClient(dynamoConfig);
-const stage = process.env.SERVERLESS_STAGE;
-const projectName = process.env.SERVERLESS_PROJECT;
-const sitesTable = projectName + '-sites-' + stage;
+const sitesTable = process.env.TABLE_NAME;
 
 module.exports.createSite = (site) => {
   return new Promise((resolve, reject) => {

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
-  region: ${env:AWS_DEFAULT_REGION, 'us-east-1'}
+  region: ${env:AWS_REGION, 'us-east-1'}
   memorySize: 128
   cfLogs: true
   iamRoleStatements:
@@ -25,8 +25,7 @@ provider:
         - "sns:Publish"
       Resource: "${self:resources.Outputs.SitesSNSTopicArn.Value}"
   environment:
-    SERVERLESS_PROJECT: ${self:service}
-    SERVERLESS_STAGE: ${self:custom.stage}
+    TABLE_NAME: { "Ref": "SitesDynamo" }
   #apiKeys:
   #  - ${self:service}-${self:custom.stage}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,9 +7,8 @@ custom:
 
 provider:
   name: aws
-  stage: dev
-  region: ap-northeast-1
-  runtime: nodejs4.3
+  runtime: nodejs6.10
+  region: ap-southeast-2
   memorySize: 128
   cfLogs: true
   iamRoleStatements:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
-  region: ap-southeast-2
+  region: ${env:AWS_DEFAULT_REGION}
   memorySize: 128
   cfLogs: true
   iamRoleStatements:
@@ -28,7 +28,7 @@ provider:
     SERVERLESS_PROJECT: ${self:service}
     SERVERLESS_STAGE: ${self:custom.stage}
   #apiKeys:
-  #  - some-api-key-name
+  #  - ${self:service}-${self:custom.stage}
 
 functions:
   dashboard:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
-  region: ${env:AWS_DEFAULT_REGION}
+  region: ${env:AWS_DEFAULT_REGION, 'us-east-1'}
   memorySize: 128
   cfLogs: true
   iamRoleStatements:


### PR DESCRIPTION
Did several improvements, please review.

- Remove the region hard code, now you can define environment variable `AWS_REGION` to override the default region easily.
- Remove the duplicate codes to define `sitesTable`, you can get reference directly from the DynamoDB resource `TABLE_NAME: { "Ref": "SitesDynamo" }`
- promote the codes to `nodejs6.10`
- Give a reasonable sample for `apiKeys` name.